### PR TITLE
Allow stockpile zones on cells containing wall-mounted heaters or AC units

### DIFF
--- a/1.6/Defs/NetDefs/ACNet.xml
+++ b/1.6/Defs/NetDefs/ACNet.xml
@@ -360,7 +360,6 @@
 		<fillPercent>0</fillPercent>
 		<overrideMinifiedRot>North</overrideMinifiedRot>
 		<minifiedDrawOffset>(0, 0, 0.2)</minifiedDrawOffset>
-		<canOverlapZones>false</canOverlapZones>
 		<castEdgeShadows>false</castEdgeShadows>
 		<uiIconPath>Things/Building/WallMountedAC/WallMountedAC_MenuIcon</uiIconPath>
 		<statBases>

--- a/1.6/Defs/ThingDefs_Buildings/Buildings_Temperature.xml
+++ b/1.6/Defs/ThingDefs_Buildings/Buildings_Temperature.xml
@@ -218,7 +218,6 @@
 		<pathCost>0</pathCost>
 		<blockWind>true</blockWind>
 		<fillPercent>0</fillPercent>
-		<canOverlapZones>false</canOverlapZones>
 		<castEdgeShadows>false</castEdgeShadows>
 		<uiIconPath>Things/Building/WallMountedHeater/WallMountedHeater_MenuIcon</uiIconPath>
 		<statBases>


### PR DESCRIPTION
Currently, buildings can be placed on a cell containing wall-mounted heaters or wall-mounted AC units, but not stockpile zones, which is counterintuitive. This PR will allow stockpile zones and wall-mounted heaters or wall-mounted AC units to occupy the same cell.